### PR TITLE
Static Playoffs View

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -34,7 +34,8 @@ var m = angular.module('app', [
   'app.player',
   'app.registration',
   'app.rules',
-  'app.team'
+  'app.team',
+  'app.playoffs'
 ]);
 
 m.run(function (AuthService) {

--- a/client/app/navigation/navigation.html
+++ b/client/app/navigation/navigation.html
@@ -62,7 +62,7 @@
     <li ui-sref="kynarilaarnio.group" class="navigation-item navigation-link">
       <span translate>global.navigation.groups</span>
     </li>
-    <li class="navigation-item navigation-link">
+    <li ui-sref="kynarilaarnio.playoffs" class="navigation-item navigation-link">
       <span translate>global.navigation.brackets</span>
     </li>
     <li ui-sref="kynarilaarnio.rules" class="navigation-item navigation-link">

--- a/client/app/playoffs/_playoffs.scss
+++ b/client/app/playoffs/_playoffs.scss
@@ -1,0 +1,65 @@
+// Based on http://codepen.io/aronduby/pen/qliuj
+
+$playoff-tree-branch-color: #aaa;
+$playoff-tree-branch-width: 1px;
+
+.playoff-tree__wrapper {
+  overflow: scroll;
+}
+
+
+// Flex all the things!
+section.playoff-tree {
+  display: flex;
+  flex-direction: row;
+}
+.round {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 200px;
+  list-style: none;
+  padding: 0;
+}
+
+.round .spacer { flex-grow: 1; }
+
+.round .spacer:first-child,
+.round .spacer:last-child {
+  flex-grow: .5;
+}
+.round .game-spacer{
+  flex-grow: 1;
+}
+
+
+
+
+
+
+li.game {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+li.game.winner{
+  font-weight: bold;
+}
+
+li.game span{
+  float: right;
+  margin-right: 5px;
+}
+
+li.game-top {
+  border-bottom: $playoff-tree-branch-width solid $playoff-tree-branch-color;
+}
+
+li.game-spacer{
+  border-right: $playoff-tree-branch-width solid $playoff-tree-branch-color;
+  min-height: 40px;
+}
+
+li.game-bottom{
+  border-top: $playoff-tree-branch-width solid $playoff-tree-branch-color;
+}

--- a/client/app/playoffs/_playoffs.scss
+++ b/client/app/playoffs/_playoffs.scss
@@ -8,7 +8,7 @@ $playoff-tree-branch-width: 1px;
 }
 
 
-// Flex all the things!
+// # Flex all the things!
 section.playoff-tree {
   display: flex;
   flex-direction: row;
@@ -22,31 +22,49 @@ section.playoff-tree {
   padding: 0;
 }
 
-.round .spacer { flex-grow: 1; }
-
-.round .spacer:first-child,
-.round .spacer:last-child {
-  flex-grow: .5;
-}
-.round .game-spacer{
+.round .spacer {
   flex-grow: 1;
 }
 
+.round .spacer:first-child,
+.round .spacer:last-child,
+.round .spacer-first,
+.round .spacer-last {
+  flex-grow: .5;
+}
+
+.round .game-spacer {
+  flex-grow: 1;
+}
+
+// # Special rules (hacks) for the loser's bracket
+.playoff-tree__wrapper--losers {
+  .round-1 .spacer:first-child { flex-grow: 2; }
+  .round-1 .spacer { flex-grow: .5; }
+
+  .round-2 .spacer:first-child { flex-grow: 1; }
+  .round-2 .spacer { flex-grow: 4; }
+  .round-2 .spacer:last-child { flex-grow: 12; }
+
+  .round-3 .spacer:first-child { flex-grow: 6; }
+  .round-3 .spacer { flex-grow: 10; }
+  .round-3 .game-spacer { flex-grow: 10; }
+}
 
 
 
 
-
+// # Styling for items
 li.game {
   padding-left: 20px;
   margin-bottom: 0;
 }
 
-li.game.winner{
+li.game.winner {
   font-weight: bold;
 }
 
-li.game span{
+li.game span {
   float: right;
   margin-right: 5px;
 }
@@ -55,11 +73,11 @@ li.game-top {
   border-bottom: $playoff-tree-branch-width solid $playoff-tree-branch-color;
 }
 
-li.game-spacer{
+li.game-spacer {
   border-right: $playoff-tree-branch-width solid $playoff-tree-branch-color;
   min-height: 40px;
 }
 
-li.game-bottom{
+li.game-bottom {
   border-top: $playoff-tree-branch-width solid $playoff-tree-branch-color;
 }

--- a/client/app/playoffs/_playoffs.scss
+++ b/client/app/playoffs/_playoffs.scss
@@ -12,6 +12,11 @@ $playoff-tree-branch-width: 1px;
 section.playoff-tree {
   display: flex;
   flex-direction: row;
+
+  // make the bracket scrollable in x-axis
+  min-width: 800px;
+  width: 100%;
+  ul { width: 100%; }
 }
 .round {
   display: flex;

--- a/client/app/playoffs/playoffs.html
+++ b/client/app/playoffs/playoffs.html
@@ -2,27 +2,6 @@
   <i class="fa fa-group"></i> <span translate>playoffs.title</span>
 </akl-hero>
 
-
-<!-- <div class="row playoff-tree__wrapper">
-  TODO REMOVE THIS BEFORE GOING INTO PRODUCTION
-
-  <section class="playoff-tree">
-    <ul class="round" ng-repeat="round in rounds" ng-class="'round-' + round.roundNumber">
-      <div ng-repeat="matchPair in round.matchPairs">
-        <li class="spacer" ng-class="{ 'spacer-first': $first }" ng-if="$first">&nbsp;</li>
-
-        <li class="game game-top winner">{{matchPair}}-A <span>99</span></li>
-        <li class="game game-spacer">&nbsp;</li>
-        <li class="game game-bottom">{{matchPair}}-B <span>99</span></li>
-
-        <li class="spacer" ng-class="{ 'spacer-last': $last }">&nbsp;</li>
-      </div>
-
-    </ul>
-  </section>
-</div> -->
-
-
 <div class="row">
   <h3>Winner's Bracket</h3>
 

--- a/client/app/playoffs/playoffs.html
+++ b/client/app/playoffs/playoffs.html
@@ -2,119 +2,246 @@
   <i class="fa fa-group"></i> <span translate>playoffs.title</span>
 </akl-hero>
 
-<div class="row playoff-tree__wrapper">
+
+<!-- <div class="row playoff-tree__wrapper">
+  TODO REMOVE THIS BEFORE GOING INTO PRODUCTION
+
   <section class="playoff-tree">
-    <ul class="round round-1">
-      <li class="spacer">&nbsp;</li>
+    <ul class="round" ng-repeat="round in rounds" ng-class="'round-' + round.roundNumber">
+      <div ng-repeat="matchPair in round.matchPairs">
+        <li class="spacer" ng-class="{ 'spacer-first': $first }" ng-if="$first">&nbsp;</li>
 
-      <li class="game game-top winner">Lousville <span>79</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">NC A&T <span>48</span></li>
+        <li class="game game-top winner">{{matchPair}}-A <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">{{matchPair}}-B <span>99</span></li>
 
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Colo St <span>84</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Missouri <span>72</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top ">Oklahoma St <span>55</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom winner">Oregon <span>68</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Saint Louis <span>64</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">New Mexico St <span>44</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Memphis <span>54</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">St Mary's <span>52</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Mich St <span>65</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Valparaiso <span>54</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Creighton <span>67</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Cincinnati <span>63</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Duke <span>73</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Albany <span>61</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-    </ul>
-
-    <ul class="round round-2">
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Lousville <span>82</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Colo St <span>56</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Oregon <span>74</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Saint Louis <span>57</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top ">Memphis <span>48</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom winner">Mich St <span>70</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top ">Creighton <span>50</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom winner">Duke <span>66</span></li>
-
-      <li class="spacer">&nbsp;</li>
-    </ul>
-
-    <ul class="round round-3">
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Lousville <span>77</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Oregon <span>69</span></li>
-
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top ">Mich St <span>61</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom winner">Duke <span>71</span></li>
-
-      <li class="spacer">&nbsp;</li>
-    </ul>
-
-    <ul class="round round-4">
-      <li class="spacer">&nbsp;</li>
-
-      <li class="game game-top winner">Lousville <span>85</span></li>
-      <li class="game game-spacer">&nbsp;</li>
-      <li class="game game-bottom ">Duke <span>63</span></li>
-
-      <li class="spacer">&nbsp;</li>
-    </ul>
-
-    <ul class="round round-5">
-      <li class="game game-top winner">KEIJOO <span>85</span></li>
+        <li class="spacer" ng-class="{ 'spacer-last': $last }">&nbsp;</li>
+      </div>
 
     </ul>
   </section>
+</div> -->
 
+
+<div class="row">
+  <h3>Winner's Bracket</h3>
+
+  <div class="playoff-tree__wrapper">
+    <section class="playoff-tree">
+      <ul class="round round-1">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top winner">A1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">H2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">B1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">G2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">C1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">F2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">D1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">E2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">E1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">D2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">F1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">C2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">G1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">B2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">H1 <span>99</span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">A2 <span>99</span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+      </ul>
+
+      <ul class="round round-2">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-3">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-4">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-5">
+        <li class="game game-top"> <span></span></li>
+      </ul>
+
+    </section>
+  </div>
+
+
+
+  <h3>Loser's Bracket</h3>
+
+  <div class="playoff-tree__wrapper playoff-tree__wrapper--losers">
+    <section class="playoff-tree">
+      <ul class="round round-1">
+        <li class="spacer">&nbsp;</li>
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L1 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">L2 <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L3 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">L4 <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L5 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">L6 <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L7 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom">L8 <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+
+      </ul>
+
+      <ul class="round round-2">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L16 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L15 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L14 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top">L13 <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-3">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-4">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+        <li class="game game-spacer">&nbsp;</li>
+        <li class="game game-bottom"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+      <ul class="round round-5">
+        <li class="spacer">&nbsp;</li>
+
+        <li class="game game-top"> <span></span></li>
+
+        <li class="spacer">&nbsp;</li>
+      </ul>
+
+    </section>
+
+  </div>
 </div>

--- a/client/app/playoffs/playoffs.html
+++ b/client/app/playoffs/playoffs.html
@@ -3,7 +3,7 @@
 </akl-hero>
 
 <div class="row">
-  <h3>Winner's Bracket</h3>
+  <h3 translate>playoffs.winnersBracket</h3>
 
   <div class="playoff-tree__wrapper">
     <section class="playoff-tree">
@@ -123,7 +123,7 @@
 
 
 
-  <h3>Loser's Bracket</h3>
+  <h3 translate>playoffs.losersBracket</h3>
 
   <div class="playoff-tree__wrapper playoff-tree__wrapper--losers">
     <section class="playoff-tree">

--- a/client/app/playoffs/playoffs.html
+++ b/client/app/playoffs/playoffs.html
@@ -1,0 +1,120 @@
+<akl-hero>
+  <i class="fa fa-group"></i> <span translate>playoffs.title</span>
+</akl-hero>
+
+<div class="row playoff-tree__wrapper">
+  <section class="playoff-tree">
+    <ul class="round round-1">
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Lousville <span>79</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">NC A&T <span>48</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Colo St <span>84</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Missouri <span>72</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top ">Oklahoma St <span>55</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom winner">Oregon <span>68</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Saint Louis <span>64</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">New Mexico St <span>44</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Memphis <span>54</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">St Mary's <span>52</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Mich St <span>65</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Valparaiso <span>54</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Creighton <span>67</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Cincinnati <span>63</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Duke <span>73</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Albany <span>61</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+    </ul>
+
+    <ul class="round round-2">
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Lousville <span>82</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Colo St <span>56</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Oregon <span>74</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Saint Louis <span>57</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top ">Memphis <span>48</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom winner">Mich St <span>70</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top ">Creighton <span>50</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom winner">Duke <span>66</span></li>
+
+      <li class="spacer">&nbsp;</li>
+    </ul>
+
+    <ul class="round round-3">
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Lousville <span>77</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Oregon <span>69</span></li>
+
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top ">Mich St <span>61</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom winner">Duke <span>71</span></li>
+
+      <li class="spacer">&nbsp;</li>
+    </ul>
+
+    <ul class="round round-4">
+      <li class="spacer">&nbsp;</li>
+
+      <li class="game game-top winner">Lousville <span>85</span></li>
+      <li class="game game-spacer">&nbsp;</li>
+      <li class="game game-bottom ">Duke <span>63</span></li>
+
+      <li class="spacer">&nbsp;</li>
+    </ul>
+
+    <ul class="round round-5">
+      <li class="game game-top winner">KEIJOO <span>85</span></li>
+
+    </ul>
+  </section>
+
+</div>

--- a/client/app/playoffs/playoffs.js
+++ b/client/app/playoffs/playoffs.js
@@ -17,4 +17,26 @@ m.config(function ($stateProvider) {
 
 m.controller('PlayoffsController', function ($scope) {
   $scope.keke = 'test';
+
+  // TODO: this would be cool.. see template. But the extra divs that
+  // ng-repeat generates breaks flexbox
+  $scope.rounds = [
+    {
+      roundNumber: 1,
+      matchPairs: [1,2,3,4,5,6,7,8]
+    },
+    {
+      roundNumber: 2,
+      matchPairs: [9,10,11,12]
+    },
+    {
+      roundNumber: 3,
+      matchPairs: [13,14]
+    },
+    {
+      roundNumber: 4,
+      matchPairs: [15]
+    }
+
+  ];
 });

--- a/client/app/playoffs/playoffs.js
+++ b/client/app/playoffs/playoffs.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var m = angular.module('app.playoffs', []);
+
+m.config(function ($stateProvider) {
+  $stateProvider
+    .state('kynarilaarnio.playoffs', {
+      url: 'playoffs',
+      views: {
+        'main@': {
+          templateUrl: 'playoffs/playoffs.html',
+          controller: 'PlayoffsController'
+        }
+      }
+    });
+});
+
+m.controller('PlayoffsController', function ($scope) {
+  $scope.keke = 'test';
+});

--- a/client/app/playoffs/playoffs.js
+++ b/client/app/playoffs/playoffs.js
@@ -16,27 +16,5 @@ m.config(function ($stateProvider) {
 });
 
 m.controller('PlayoffsController', function ($scope) {
-  $scope.keke = 'test';
-
-  // TODO: this would be cool.. see template. But the extra divs that
-  // ng-repeat generates breaks flexbox
-  $scope.rounds = [
-    {
-      roundNumber: 1,
-      matchPairs: [1,2,3,4,5,6,7,8]
-    },
-    {
-      roundNumber: 2,
-      matchPairs: [9,10,11,12]
-    },
-    {
-      roundNumber: 3,
-      matchPairs: [13,14]
-    },
-    {
-      roundNumber: 4,
-      matchPairs: [15]
-    }
-
-  ];
+  // nothing here, do everything manually :(
 });

--- a/client/assets/i18n/fi.json
+++ b/client/assets/i18n/fi.json
@@ -105,5 +105,9 @@
     "codesSearchString": "Hakusana",
     "showRedeemed": "Näytä aktivoidut",
     "codeAmountUnit": "koodia"
+  },
+
+  "playoffs": {
+    "title": "Pudotuspelit"
   }
 }

--- a/client/assets/i18n/fi.json
+++ b/client/assets/i18n/fi.json
@@ -108,6 +108,8 @@
   },
 
   "playoffs": {
-    "title": "Pudotuspelit"
+    "title": "Pudotuspelit",
+    "winnersBracket": "Winners Bracket",
+    "losersBracket": "Losers Bracket"
   }
 }

--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -7,6 +7,7 @@
 
 // "components"
 @import '../app/hero/hero';
+@import '../app/footer/footer';
 
 // "view specific" styles
 @import '../app/admin/admin';
@@ -16,4 +17,4 @@
 @import '../app/navigation/navigation';
 @import '../app/player/player';
 @import '../app/team/team';
-@import '../app/footer/footer';
+@import '../app/playoffs/playoffs';


### PR DESCRIPTION
Create static version of the tournament bracket in use. Based on this [aronduby's codepen](http://codepen.io/aronduby/pen/qliuj). 

Bracket has `min-width: 800px`, so it will scroll horizontally on smaller screens.

<img width="1085" alt="screen shot 2015-08-27 at 23 07 37" src="https://cloud.githubusercontent.com/assets/4402654/9531792/7841a87c-4d10-11e5-9681-205a553decb5.png">

<img width="1052" alt="screen shot 2015-08-27 at 23 07 43" src="https://cloud.githubusercontent.com/assets/4402654/9531793/78427a0e-4d10-11e5-8d36-9619835a4bd7.png">

(I tried to do this dynamically [on some level], but the way how `ng-repeat` adds `div`-nodes to repeats messes up the flexbox-layout this model uses so it was a no-go)
